### PR TITLE
Fix missing config imports causing blank dashboard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,19 +2,10 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Package, MapPin, Database, AlertTriangle, Truck, Sun, Moon, ArrowDown, X, ChevronRight, Clock, Info, Check, Filter, Search, Settings, Save, Edit2, AlertCircle } from 'lucide-react';
 import apiService from './services/apiService';
 import wsService from './services/websocketService';
+import CONFIG from './config';
 import { ConnectionProvider, useConnection } from './contexts/ConnectionContext';
 import { NotificationProvider, useNotification } from './contexts/NotificationContext';
 import ConnectionStatus from './components/ConnectionStatus';
-
-// ==================== CONFIGURACIÓN ====================
-const CONFIG = {
-  API_BASE_URL: 'http://localhost:3001/api',
-  POLLING_INTERVAL: 30000, // 30 segundos
-  WEBSOCKET_URL: 'ws://localhost:3001',
-  CACHE_DURATION: 5 * 60 * 1000, // 5 minutos
-  ENABLE_WEBSOCKETS: false, // Cambiar a true cuando esté disponible el servidor WS
-};
-
 // ==================== SERVICIO API ====================
 
 // ==================== CONSTANTES ====================

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,9 @@
+export const CONFIG = {
+  API_BASE_URL: 'http://localhost:3001/api',
+  POLLING_INTERVAL: 30000, // 30 segundos
+  WEBSOCKET_URL: 'ws://localhost:3001',
+  CACHE_DURATION: 5 * 60 * 1000, // 5 minutos
+  ENABLE_WEBSOCKETS: false // Cambiar a true cuando esté disponible el servidor WS
+};
+
+export default CONFIG;

--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -1,3 +1,4 @@
+import CONFIG from '../config';
 // ==================== SERVICIO API ====================
 class ApiService {
   constructor() {

--- a/src/services/websocketService.js
+++ b/src/services/websocketService.js
@@ -1,3 +1,4 @@
+import CONFIG from '../config';
 // ==================== WEBSOCKET SERVICE ====================
 class WebSocketService {
   constructor() {


### PR DESCRIPTION
## Summary
- centralize app configuration in a new `config.js`
- import the shared config where needed

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run dev` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68472683defc83339194bdd127af99c1